### PR TITLE
module format

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./src');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oc-template-handlebars",
   "version": "1.0.0",
   "description": "OC-Template-handlebars",
-  "main": "index.js",
+  "main": "src",
   "scripts": {
     "precommit": "npm run test",
     "lint": "eslint .",

--- a/src/getInfo.spec.js
+++ b/src/getInfo.spec.js
@@ -1,4 +1,4 @@
-const getInfo = require('../src/getInfo');
+const getInfo = require('./getInfo');
 
 describe('getInfo method', () => {
   describe('when invoking the method', () => {

--- a/src/precompile.spec.js
+++ b/src/precompile.spec.js
@@ -1,5 +1,5 @@
 const handlebars = require('handlebars');
-const precompile = require('../src/precompile');
+const precompile = require('./precompile');
 
 describe('precompile method', () => {
   describe('when invoking the method', () => {

--- a/src/render.spec.js
+++ b/src/render.spec.js
@@ -2,9 +2,9 @@
 
 const handlebars = require('handlebars');
 
-jest.mock('../src/utils');
-const utils = require('../src/utils');
-const render = require('../src/render');
+jest.mock('./utils');
+const utils = require('./utils');
+const render = require('./render');
 
 const callback = jest.fn();
 const options = {

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,4 +1,4 @@
-const utils = require('../src/utils');
+const utils = require('./utils');
 
 describe('utils module', () => {
   describe('when validating component', () => {


### PR DESCRIPTION
We were having an index in the root as entry but we could point directly to src instead as it expose its api via index