### PR TITLE
[MAJOR][GPT-525] externals API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
   "name": "oc-template-handlebars",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "OC-Template-Handlebars",
   "main": "src",
   "scripts": {
     "precommit": "npm run test",
     "lint": "eslint .",
     "test": "npm run lint && jest"
-  },
-  "info": {
-    "type": "handlebars"
   },
   "repository": {
     "type": "git",
@@ -30,6 +27,12 @@
     "jest": "^18.1.0"
   },
   "dependencies": {
-    "handlebars": "^4.0.6"
+    "handlebars": "4.0.6"
+  },
+  "externals": {
+    "handlebars": {
+      "global": "Handlebars",
+      "url": "https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/handlebars.runtime.min.js"
+    }
   }
 }

--- a/src/__snapshots__/getInfo.spec.js.snap
+++ b/src/__snapshots__/getInfo.spec.js.snap
@@ -1,5 +1,14 @@
 exports[`getInfo method when invoking the method should return the list of dependencies 1`] = `
 Object {
-  "handlebars": "^4.0.6",
+  "handlebars": "4.0.6",
 }
+`;
+
+exports[`getInfo method when invoking the method should return the list of externals 1`] = `
+Array [
+  Object {
+    "global": "Handlebars",
+    "url": "https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/handlebars.runtime.min.js",
+  },
+]
 `;

--- a/src/getInfo.js
+++ b/src/getInfo.js
@@ -3,7 +3,10 @@
 const packageJson = require('../package.json');
 
 module.exports = () => ({
-  type: packageJson.info.type,
+  type: packageJson.name,
   version: packageJson.version,
-  dependencies: packageJson.dependencies
+  dependencies: packageJson.dependencies,
+  externals: [
+    packageJson.externals['handlebars']
+  ]
 });

--- a/src/getInfo.spec.js
+++ b/src/getInfo.spec.js
@@ -8,10 +8,13 @@ describe('getInfo method', () => {
       expect(info.version).toBeDefined();
     });
     test('should return the correct template type', () => {
-      expect(info.type).toBe('handlebars');
+      expect(info.type).toBe('oc-template-handlebars');
     });
     test('should return the list of dependencies', () => {
       expect(info.dependencies).toMatchSnapshot();
+    });
+    test('should return the list of externals', () => {
+      expect(info.externals).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Get info now provide externals as an array of ordered external dependencies.
Template type is now aligned with template name, making it univoque
