### PR TITLE
[GPT-527] Full precompilation within the template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-template-handlebars",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "OC-Template-Handlebars",
   "main": "src",
   "scripts": {

--- a/src/compile.js
+++ b/src/compile.js
@@ -4,8 +4,10 @@ const handlebars = require('handlebars');
 
 module.exports = (options, callback) => {
   var compiled;
+  var templateSpec;
   try {
-    compiled = handlebars.precompile(options.template);
+    templateSpec = handlebars.precompile(options.template);
+    compiled = handlebars.template(templateSpec, []);
   } catch (err) {
     return callback(err);
   }

--- a/src/compile.spec.js
+++ b/src/compile.spec.js
@@ -10,6 +10,9 @@ describe('compile method', () => {
     test('should correctly invoke handlebars precompile method', () => {
       expect(handlebars.precompile).toBeCalledWith(template);
     });
+    test('should correctly invoke handlebars template method', () => {
+      expect(handlebars.template).toBeCalled();
+    });
     test('should correctly invoke the callback', () => {
       expect(callback).toBeCalled();
     });


### PR DESCRIPTION
At the moment prviously published components are safe but new ones are not as we treat them all the same if not type 'handlebars' : https://github.com/opentable/oc/blob/master/src/components/oc-client/src/oc-client.js#L340-L346

this pr fixes that